### PR TITLE
Fix deprecated functions (method_exists, Flux.argmax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ the `datasets/`. The `Metalhead.download` function can be used to download these
 (where such automatic download is possible - for other data sets, see `datasets/README.md`),
 e.g.:
 ```
-MetalHead.download(CIFAR10)
+Metalhead.download(CIFAR10)
 ```
 
 Once a dataset is load, it's training, validation, and test images are available using the

--- a/src/display/terminal.jl
+++ b/src/display/terminal.jl
@@ -55,7 +55,7 @@ function print_frame_table(image_callback, frames::Vector{PredictionFrame})
                 else
                     ground_truth = p.ground_truth
                     if typeof(pred[1]) != typeof(ground_truth)
-                        if method_exists(convert, Tuple{Type{typeof(pred[1])}, typeof(ground_truth)})
+                        if hasmethod(convert, Tuple{Type{typeof(pred[1])}, typeof(ground_truth)})
                             ground_truth = convert(typeof(pred[1]), ground_truth)
                         else
                             ground_truth = nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -80,7 +80,7 @@ ground_truth(m, s::Union{AbstractMatrix, AbstractString}, result) = (nothing, 0.
 function ground_truth(m::ClassificationModel{Class}, im::ValidationImage, result) where {Class}
     if typeof(im.ground_truth) == Class
         (im.ground_truth, result[im.ground_truth.class])
-    elseif method_exists(convert, Tuple{Class, typeof(im.ground_truth)})
+    elseif hasmethod(convert, Tuple{Class, typeof(im.ground_truth)})
         (im.ground_truth, result[convert(Class, im.ground_truth).class])
     else
         (im.ground_truth, 0.0)
@@ -95,7 +95,7 @@ function predict(model::ClassificationModel{Class}, im, k = 5) where {Class}
         Prediction([Class(x)=>y for (x,y) in topk(result, k)]),
         ground_truth(model, im, result)...)
 end
-classify(model::ClassificationModel, im) = Flux.argmax(forward(model, load_img(im)), labels(model))
+classify(model::ClassificationModel, im) = Flux.onecold(forward(model, load_img(im)), labels(model))
 
 function predict(model::ClassificationModel{Class},
         im::Vector{<:Union{AbstractMatrix, String, ValidationImage}}, k=5) where Class


### PR DESCRIPTION
Fixed some deprecated functions
- Warning: `method_exists(f, t)` is deprecated, use `hasmethod(f, t)` instead.
- Warning: `argmax(...)` is deprecated, use `onecold(...)` instead.