### PR TITLE
Simplify construction for some models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Metalhead"
 uuid = "dbeba491-748d-5e0e-a39e-b530a07fa0cc"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/densenet.jl
+++ b/src/densenet.jl
@@ -147,7 +147,7 @@ Set `pretrain = true` to load the model with pre-trained weights for ImageNet.
 
 See also [`Metalhead.densenet`](#).
 """
-function DenseNet(config::Int; pretrain = false)
+function DenseNet(config::Int = 121; pretrain = false)
   @assert config in keys(densenet_config) "`config` must be one out of $(sort(keys(densenet_config)))."
   model = DenseNet(densenet_config[config])
 

--- a/src/densenet.jl
+++ b/src/densenet.jl
@@ -129,75 +129,34 @@ end
 backbone(m::DenseNet) = m.layers[1]
 classifier(m::DenseNet) = m.layers[2]
 
-"""
-    DenseNet121(; pretrain = false)
+const densenet_config = Dict(121 => (6, 12, 24, 16),
+                             161 => (6, 12, 36, 24),
+                             169 => (6, 12, 32, 32),
+                             201 => (6, 12, 48, 32))
 
-Create a DenseNet-121 model
+"""
+    DenseNet(config::Int = 121; pretrain = false)
+    DenseNet(transition_config::NTuple{N,Int})
+
+Create a DenseNet model with specified configuration. Currently supported values are (121, 161, 169, 201)
 ([reference](https://arxiv.org/abs/1608.06993)).
-Set `pretrain=true` to load the model with pre-trained weights for ImageNet.
+Set `pretrain = true` to load the model with pre-trained weights for ImageNet.
 
 !!! warning
-    `DenseNet121` does not currently support pretrained weights.
+    `DenseNet` does not currently support pretrained weights.
 
-See also [`Metalhead.DenseNet`](#).
+See also [`Metalhead.densenet`](#).
 """
-function DenseNet121(; pretrain = false)
-  model = DenseNet((6, 12, 24, 16))
+function DenseNet(config::Int; pretrain = false)
+  @assert config in (121, 161, 169, 201) "`config` must be one out of (121, 161, 169, 201)."
+  model = DenseNet(densenet_config[depth])
 
-  pretrain && loadpretrain!(model, "DenseNet121")
+  pretrain && loadpretrain!(model, string("DenseNet", config))
   return model
 end
 
-"""
-    DenseNet161(; pretrain = false)
-
-Create a DenseNet-161 model
-([reference](https://arxiv.org/abs/1608.06993)).
-
-!!! warning
-    `DenseNet161` does not currently support pretrained weights.
-
-See also [`Metalhead.DenseNet`](#).
-"""
-function DenseNet161(; pretrain = false)
-  model = DenseNet((6, 12, 36, 24); growth_rate = 64)
-
-  pretrain && loadpretrain!(model, "DenseNet161")
-  return model
-end
-
-"""
-    DenseNet169(; pretrain = false)
-
-Create a DenseNet-169 model
-([reference](https://arxiv.org/abs/1608.06993)).
-
-!!! warning
-    `DenseNet169` does not currently support pretrained weights.
-
-See also [`Metalhead.DenseNet`](#).
-"""
-function DenseNet169(; pretrain = false)
-  model = DenseNet((6, 12, 32, 32))
-
-  pretrain && loadpretrain!(model, "DenseNet169")
-  return model
-end
-
-"""
-    DenseNet201(; pretrain = false)
-
-Create a DenseNet-201 model
-([reference](https://arxiv.org/abs/1608.06993)).
-
-!!! warning
-    `DenseNet201` does not currently support pretrained weights.
-
-See also [`Metalhead.DenseNet`](#).
-"""
-function DenseNet201(; pretrain = false)
-  model = DenseNet((6, 12, 48, 32))
-
-  pretrain && loadpretrain!(model, "DenseNet201")
-  return model
-end
+# deprecations
+@deprecate DenseNet121(; kw...) DenseNet(121; kw...)
+@deprecate DenseNet161(; kw...) DenseNet(161; kw...)
+@deprecate DenseNet169(; kw...) DenseNet(169; kw...)
+@deprecate DenseNet201(; kw...) DenseNet(201; kw...)

--- a/src/densenet.jl
+++ b/src/densenet.jl
@@ -148,7 +148,7 @@ Set `pretrain = true` to load the model with pre-trained weights for ImageNet.
 See also [`Metalhead.densenet`](#).
 """
 function DenseNet(config::Int = 121; pretrain = false)
-  @assert config in keys(densenet_config) "`config` must be one out of $(sort(keys(densenet_config)))."
+  @assert config in keys(densenet_config) "`config` must be one out of $(sort(collect(keys(densenet_config))))."
   model = DenseNet(densenet_config[config])
 
   pretrain && loadpretrain!(model, string("DenseNet", config))

--- a/src/densenet.jl
+++ b/src/densenet.jl
@@ -148,8 +148,8 @@ Set `pretrain = true` to load the model with pre-trained weights for ImageNet.
 See also [`Metalhead.densenet`](#).
 """
 function DenseNet(config::Int; pretrain = false)
-  @assert config in (121, 161, 169, 201) "`config` must be one out of (121, 161, 169, 201)."
-  model = DenseNet(densenet_config[depth])
+  @assert config in keys(densenet_config) "`config` must be one out of $(sort(keys(densenet_config)))."
+  model = DenseNet(densenet_config[config])
 
   pretrain && loadpretrain!(model, string("DenseNet", config))
   return model

--- a/src/resnet.jl
+++ b/src/resnet.jl
@@ -214,7 +214,7 @@ See also [`Metalhead.resnet`](#).
     Only `ResNet(50)` currently supports pretrained weights.
 """
 function ResNet(depth::Int = 50; pretrain = false, nclasses = 1000)
-    @assert depth in (18, 34, 50, 101, 152) "`depth` must be one of (18, 34, 50, 101, 152)"
+    @assert depth in keys(resnet_config) "`depth` must be one of $(sort(collect(keys(resnet_config))))"
 
     config, block = resnet_config[depth]
     model = ResNet(config...; block = block, nclasses = nclasses)

--- a/src/resnet.jl
+++ b/src/resnet.jl
@@ -211,3 +211,10 @@ function ResNet(depth = 50; pretrain = false, nclasses = 1000)
     pretrain && loadpretrain!(model, string("ResNet", config))
     model
 end
+
+# Compat with Methalhead 0.6; remove in 0.7
+@deprecate ResNet18() ResNet(18)
+@deprecate ResNet34() ResNet(34)
+@deprecate ResNet50() ResNet(50)
+@deprecate ResNet101() ResNet(101)
+@deprecate ResNet152() ResNet(152)

--- a/src/resnet.jl
+++ b/src/resnet.jl
@@ -29,7 +29,7 @@ Create a bottleneck residual block
 - `downsample`: set to `true` to downsample the input
 """
 function bottleneck(inplanes, outplanes, downsample = false)
-  stride = downsample : 2 : 1
+  stride = downsample ? 2 : 1
   Chain(conv_bn((1, 1), inplanes, outplanes[1]; stride = stride, bias = false)...,
         conv_bn((3, 3), outplanes[1], outplanes[2]; stride = 1, pad = 1, bias = false)...,
         conv_bn((1, 1), outplanes[2], outplanes[3], identity; stride = 1, bias = false)...)

--- a/src/resnet.jl
+++ b/src/resnet.jl
@@ -214,6 +214,8 @@ See also [`Metalhead.resnet`](#).
     Only `ResNet(50)` currently supports pretrained weights.
 """
 function ResNet(depth::Int = 50; pretrain = false, nclasses = 1000)
+    @assert depth in (18, 34, 50, 101, 152) "`depth` must be one of (18, 34, 50, 101, 152)"
+
     config, block = resnet_config[depth]
     model = ResNet(config...; block = block, nclasses = nclasses)
     pretrain && loadpretrain!(model, string("ResNet", depth))

--- a/src/resnet.jl
+++ b/src/resnet.jl
@@ -10,11 +10,11 @@ Create a basic residual block
                within the residual block
 - `downsample`: set to `true` to downsample the input
 """
-basicblock(inplanes, outplanes, downsample = false) = downsample ?
-  Chain(conv_bn((3, 3), inplanes, outplanes[1]; stride = 2, pad = 1, bias = false)...,
-        conv_bn((3, 3), outplanes[1], outplanes[2], identity; stride = 1, pad = 1, bias = false)...) :
-  Chain(conv_bn((3, 3), inplanes, outplanes[1]; stride = 1, pad = 1, bias = false)...,
+function basicblock(inplanes, outplanes, downsample = false)
+  stride = downsample ? 2 : 1
+  Chain(conv_bn((3, 3), inplanes, outplanes[1]; stride = stride, pad = 1, bias = false)...,
         conv_bn((3, 3), outplanes[1], outplanes[2], identity; stride = 1, pad = 1, bias = false)...)
+end
 
 """
     bottleneck(inplanes, outplanes, downsample = false)
@@ -28,13 +28,12 @@ Create a bottleneck residual block
                within the residual block
 - `downsample`: set to `true` to downsample the input
 """
-bottleneck(inplanes, outplanes, downsample = false) = downsample ?
-  Chain(conv_bn((1, 1), inplanes, outplanes[1]; stride = 2, bias = false)...,
-        conv_bn((3, 3), outplanes[1], outplanes[2]; stride = 1, pad = 1, bias = false)...,
-        conv_bn((1, 1), outplanes[2], outplanes[3], identity; stride = 1, bias = false)...) :
-  Chain(conv_bn((1, 1), inplanes, outplanes[1]; stride = 1, bias = false)...,
+function bottleneck(inplanes, outplanes, downsample = false)
+  stride = downsample : 2 : 1
+  Chain(conv_bn((1, 1), inplanes, outplanes[1]; stride = stride, bias = false)...,
         conv_bn((3, 3), outplanes[1], outplanes[2]; stride = 1, pad = 1, bias = false)...,
         conv_bn((1, 1), outplanes[2], outplanes[3], identity; stride = 1, bias = false)...)
+end
 
 """
     skip_projection(inplanes, outplanes, downsample = false)
@@ -47,9 +46,10 @@ Create a skip projection
 - `outplanes`: the number of output feature maps
 - `downsample`: set to `true` to downsample the input
 """
-skip_projection(inplanes, outplanes, downsample = false) = downsample ? 
-  Chain(conv_bn((1, 1), inplanes, outplanes, identity; stride = 2, bias = false)...) :
-  Chain(conv_bn((1, 1), inplanes, outplanes, identity; stride = 1, bias = false)...)
+function skip_projection(inplanes, outplanes, downsample = false)
+  stride = downsample ? 2 : 1 
+  Chain(conv_bn((1, 1), inplanes, outplanes, identity; stride = stride, bias = false)...)
+end
 
 # array -> PaddedView(0, array, outplanes) for zero padding arrays
 """

--- a/src/resnet.jl
+++ b/src/resnet.jl
@@ -197,10 +197,10 @@ classifier(m::ResNet) = m.layers[2]
    
 Create a ResNet model with a specified depth
 ([reference](https://arxiv.org/abs/1512.03385v1)).
-See also [`Metalhead.ResNet`](#).
+See also [`Metalhead.resnet`](#).
 
 # Arguments
-- `depth`: depth of the ResNet model. Typically one of (18, 34, 50, 101, 152).
+- `depth`: depth of the ResNet model. Options include (18, 34, 50, 101, 152).
 - `nclasses`: the number of output classes
 
 !!! warning
@@ -208,13 +208,13 @@ See also [`Metalhead.ResNet`](#).
 """
 function ResNet(depth = 50; pretrain = false, nclasses = 1000)
     model = ResNet(resnet_config[depth]...; block = bottleneck, nclasses = nclasses)
-    pretrain && loadpretrain!(model, string("ResNet", config))
+    pretrain && loadpretrain!(model, string("ResNet", depth))
     model
 end
 
 # Compat with Methalhead 0.6; remove in 0.7
-@deprecate ResNet18() ResNet(18)
-@deprecate ResNet34() ResNet(34)
-@deprecate ResNet50() ResNet(50)
-@deprecate ResNet101() ResNet(101)
-@deprecate ResNet152() ResNet(152)
+@deprecate ResNet18(; kw...) ResNet(18; kw...)
+@deprecate ResNet34(; kw...) ResNet(34; kw...)
+@deprecate ResNet50(; kw...) ResNet(50; kw...)
+@deprecate ResNet101(; kw...) ResNet(101; kw...)
+@deprecate ResNet152(; kw...) ResNet(152; kw...)

--- a/src/resnet.jl
+++ b/src/resnet.jl
@@ -150,11 +150,11 @@ resnet(block, shortcut_config::Symbol, args...; kwargs...) =
   error("Unrecognized shortcut config == $shortcut_config passed to resnet (use :A, :B, or :C).")
 
 const resnet_config =
-  Dict(:resnet18 => ([1, 1], [2, 2, 2, 2], :A),
-       :resnet34 => ([1, 1], [3, 4, 6, 3], :A),
-       :resnet50 => ([1, 1, 4], [3, 4, 6, 3], :B),
-       :resnet101 => ([1, 1, 4], [3, 4, 23, 3], :B),
-       :resnet152 => ([1, 1, 4], [3, 8, 36, 3], :B))
+  Dict(18 => ([1, 1], [2, 2, 2, 2], :A),
+       34 => ([1, 1], [3, 4, 6, 3], :A),
+       50 => ([1, 1, 4], [3, 4, 6, 3], :B),
+       101 => ([1, 1, 4], [3, 4, 23, 3], :B),
+       152 => ([1, 1, 4], [3, 8, 36, 3], :B))
 
 """
     ResNet(channel_config, block_config, shortcut_config; block, nclasses = 1000)
@@ -193,105 +193,21 @@ backbone(m::ResNet) = m.layers[1]
 classifier(m::ResNet) = m.layers[2]
 
 """
-    ResNet18(; pretrain = false, nclasses = 1000)
+    ResNet(depth = 50; pretrain = false, nclasses = 1000)
    
-Create a ResNet-18 model
+Create a ResNet model with a specified depth
 ([reference](https://arxiv.org/abs/1512.03385v1)).
 See also [`Metalhead.ResNet`](#).
 
 # Arguments
+- `depth`: depth of the ResNet model. Typically one of (18, 34, 50, 101, 152).
 - `nclasses`: the number of output classes
 
 !!! warning
-    `ResNet18` does not currently support pretrained weights.
+    Only `ResNet(50)` currently supports pretrained weights.
 """
-function ResNet18(; pretrain = false, nclasses = 1000)
-  model = ResNet(resnet_config[:resnet18]...; block = basicblock, nclasses = nclasses)
-
-  pretrain && loadpretrain!(model, "ResNet18")
-  return model
-end
-
-"""
-    ResNet34(; pretrain = false, nclasses = 1000)
-   
-Create a ResNet-34 model
-([reference](https://arxiv.org/abs/1512.03385v1)).
-See also [`Metalhead.ResNet`](#).
-
-# Arguments
-- `pretrain`: set to `true` to load pre-trained weights for ImageNet
-- `nclasses`: the number of output classes
-
-!!! warning
-    `ResNet34` does not currently support pretrained weights.
-"""
-function ResNet34(; pretrain = false, nclasses = 1000)
-  model = ResNet(resnet_config[:resnet34]...; block = basicblock, nclasses = nclasses)
-
-  pretrain && loadpretrain!(model, "ResNet34")
-  return model
-end
-
-"""
-    ResNet50(; pretrain = false, nclasses = 1000)
-   
-Create a ResNet-50 model
-([reference](https://arxiv.org/abs/1512.03385v1)).
-See also [`Metalhead.ResNet`](#).
-
-# Arguments
-- `pretrain`: set to `true` to load pre-trained weights for ImageNet
-- `nclasses`: the number of output classes
-
-!!! warning
-    `ResNet50` does not currently support pretrained weights.
-"""
-function ResNet50(; pretrain = false, nclasses = 1000)
-  model = ResNet(resnet_config[:resnet50]...; block = bottleneck, nclasses = nclasses)
-
-  pretrain && loadpretrain!(model, "ResNet50")
-  return model
-end
-
-"""
-    ResNet101(; pretrain = false, nclasses = 1000)
-   
-Create a ResNet-101 model
-([reference](https://arxiv.org/abs/1512.03385v1)).
-See also [`Metalhead.ResNet`](#).
-
-# Arguments
-- `pretrain`: set to `true` to load pre-trained weights for ImageNet
-- `nclasses`: the number of output classes
-
-!!! warning
-    `ResNet101` does not currently support pretrained weights.
-"""
-function ResNet101(; pretrain = false, nclasses = 1000)
-  model = ResNet(resnet_config[:resnet101]...; block = bottleneck, nclasses = nclasses)
-
-  pretrain && loadpretrain!(model, "ResNet101")
-  return model
-end
-
-"""
-    ResNet152(; pretrain = false, nclasses = 1000)
-   
-Create a ResNet-152 model
-([reference](https://arxiv.org/abs/1512.03385v1)).
-See also [`Metalhead.ResNet`](#).
-
-# Arguments
-- `pretrain`: set to `true` to load pre-trained weights for ImageNet
-- `nclasses`: the number of output classes
-
-!!! warning
-    `ResNet152` does not currently support pretrained weights.
-"""
-function ResNet152(; pretrain = false, nclasses = 1000)
-  model = ResNet(resnet_config[:resnet152]...; block = bottleneck, nclasses = nclasses)
-
-  pretrain && loadpretrain!(model, "ResNet152")
-  return model
+function ResNet(depth = 50; pretrain = false, nclasses = 1000)
+    model = ResNet(resnet_config[depth]...; block = bottleneck, nclasses = nclasses)
+    pretrain && loadpretrain!(model, string("ResNet", config))
+    model
 end

--- a/src/vgg.jl
+++ b/src/vgg.jl
@@ -157,13 +157,13 @@ See also [`VGG`](#).
 # Arguments
 - `pretrain`: set to `true` to load pre-trained model weights for ImageNet
 """
-function VGG(depth::Int = 16; pretrain = false, batchnorm = false)
+function VGG(depth::Int = 16; pretrain = false, batchnorm = false, nclasses = 1000)
   @assert depth in keys(vgg_config) "depth must be from one in $(sort(collect(keys(vgg_config))))"
 
   model = VGG((224, 224); config = vgg_conv_config[vgg_config[depth]],
                           inchannels = 3,
                           batchnorm = batchnorm,
-                          nclasses = 1000,
+                          nclasses = nclasses,
                           fcsize = 4096,
                           dropout = 0.5)
 

--- a/src/vgg.jl
+++ b/src/vgg.jl
@@ -157,7 +157,7 @@ See also [`VGG`](#).
 # Arguments
 - `pretrain`: set to `true` to load pre-trained model weights for ImageNet
 """
-function VGG11(depth::Int; pretrain = false, batchnorm = false)
+function VGG(depth::Int = 16; pretrain = false, batchnorm = false)
   @assert depth in (11, 13, 16, 19) "depth must be from one in (11, 13, 16, 19)"
 
   model = VGG((224, 224); config = vgg_conv_config[vgg_config[depth]],

--- a/src/vgg.jl
+++ b/src/vgg.jl
@@ -112,9 +112,9 @@ struct VGG
 end
 
 """
-    VGG(imsize::NTuple{2,Int} = (224, 224); config, inchannels, batchnorm, nclasses, fcsize, dropout)
+    VGG(imsize::NTuple{2,Int}; config, inchannels, batchnorm, nclasses, fcsize, dropout)
 
-Construct a VGG model with the specified input image size.
+Construct a VGG model with the specified input image size. Typically, the image size is `(224, 224)`.
 
 ## Keyword Arguments:
 - `config` : VGG convolutional block configuration. It is defined as a vector of tuples `(output_channels, num_convolutions)` for each block 
@@ -125,7 +125,7 @@ Construct a VGG model with the specified input image size.
             (see [`Metalhead.vgg_classifier_layers`](#))
 - `dropout`: dropout level between fully connected layers
 """
-function VGG(imsize::NTuple{2, <:Integer} = (224, 224);
+function VGG(imsize::NTuple{2, <:Integer};
              config, inchannels, batchnorm = false, nclasses, fcsize, dropout)
   layers = vgg(imsize; config = config,
                        inchannels = inchannels,

--- a/src/vgg.jl
+++ b/src/vgg.jl
@@ -117,7 +117,7 @@ end
 Construct a VGG model with the specified input image size.
 
 ## Keyword Arguments:
-- `config`::Symbol : VGG convolutional block configuration. Can be one of (:A, :B, :D, :E)
+- `config` : VGG convolutional block configuration. It is defined as a vector of tuples `(output_channels, num_convolutions)` for each block 
 - `inchannels`::Int : number of input channels
 - `batchnorm`::Bool : set to `true` to use batch normalization after each convolution
 - `nclasses`::Int : number of output classes
@@ -128,11 +128,11 @@ Construct a VGG model with the specified input image size.
 function VGG(imsize::NTuple{2, <:Integer} = (224, 224);
              config, inchannels, batchnorm = false, nclasses, fcsize, dropout)
   layers = vgg(imsize; config = config,
-                        inchannels = inchannels,
-                        batchnorm = batchnorm,
-                        nclasses = nclasses,
-                        fcsize = fcsize,
-                        dropout = dropout)
+                       inchannels = inchannels,
+                       batchnorm = batchnorm,
+                       nclasses = nclasses,
+                       fcsize = fcsize,
+                       dropout = dropout)
   
   VGG(layers)
 end

--- a/src/vgg.jl
+++ b/src/vgg.jl
@@ -158,7 +158,7 @@ See also [`VGG`](#).
 - `pretrain`: set to `true` to load pre-trained model weights for ImageNet
 """
 function VGG(depth::Int = 16; pretrain = false, batchnorm = false)
-  @assert depth in (11, 13, 16, 19) "depth must be from one in (11, 13, 16, 19)"
+  @assert depth in keys(vgg_config) "depth must be from one in $(sort(collect(keys(vgg_config))))"
 
   model = VGG((224, 224); config = vgg_conv_config[vgg_config[depth]],
                           inchannels = 3,


### PR DESCRIPTION
Moves us from having multiple functions such as `ResNet18/34/50` etc to a unified constructor which can accept the `depth` and construct the corresponding model. It simplifies the code base by removing some stencil functions and allows us to get a default `ResNet()` method as well for backwards compatibility with Metalhead@0.5. 