### PR TITLE
Update pretrained artifacts

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -14,6 +14,14 @@ lazy = true
     sha256 = "8ab8d60cc26e81451473badc9dc749b5ffc170a11bc00fb4b203da34fbfdc996"
     url = "https://github.com/FluxML/MetalheadWeights/releases/download/v0.1.1/googlenet-0.1.1.tar.gz"
 
+[resnet18]
+git-tree-sha1 = "e686115fea748bb63e6055076bbdfd6845ad07bb"
+lazy = true
+
+    [[resnet18.download]]
+    sha256 = "749decf67c650f314dc1460fab401f8d3f6999bacaea5eec7bd257dac0dd7980"
+    url = "https://github.com/DhairyaLGandhi/dftsurr/releases/download/untagged-7fa5b55e76dcbcc95518/resnet18-0.6.1.tar.gz"
+
 [resnet34]
 git-tree-sha1 = "6101dc5ccee820d41ddfcb4be09a1b074d96e477"
 lazy = true

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -14,6 +14,14 @@ lazy = true
     sha256 = "8ab8d60cc26e81451473badc9dc749b5ffc170a11bc00fb4b203da34fbfdc996"
     url = "https://github.com/FluxML/MetalheadWeights/releases/download/v0.1.1/googlenet-0.1.1.tar.gz"
 
+[resnet34]
+git-tree-sha1 = "6101dc5ccee820d41ddfcb4be09a1b074d96e477"
+lazy = true
+
+    [[resnet34.download]]
+    sha256 = "749decf67c650f314dc1460fab401f8d3f6999bacaea5eec7bd257dac0dd7980"
+    url = "https://github.com/DhairyaLGandhi/dftsurr/releases/download/untagged-7fa5b55e76dcbcc95518/resnet34-0.6.1.tar.gz"
+
 [resnet50]
 git-tree-sha1 = "661497926a2a5aa709e79fc44cc9cb3d930e1c91"
 lazy = true

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -15,12 +15,12 @@ lazy = true
     url = "https://github.com/FluxML/MetalheadWeights/releases/download/v0.1.1/googlenet-0.1.1.tar.gz"
 
 [resnet50]
-git-tree-sha1 = "ea3effeaf1ea3969ed5c609f5db5cd0e456ce799"
+git-tree-sha1 = "661497926a2a5aa709e79fc44cc9cb3d930e1c91"
 lazy = true
 
     [[resnet50.download]]
-    sha256 = "17760ae50e3d59ed7d74c3dfcdb9f0eeaccec1e2ccd095663955c9fed4f318a8"
-    url = "https://github.com/FluxML/MetalheadWeights/releases/download/v0.1.1/resnet50-0.1.1.tar.gz"
+    sha256 = "58b6f1551a3e76da0aea137d40ab2c41d128fe9705b02f8e3167e647644b57a7"
+    url = "https://github.com/DhairyaLGandhi/dftsurr/releases/download/untagged-7fa5b55e76dcbcc95518/resnet50-0.6.1.tar.gz"
 
 [squeezenet]
 git-tree-sha1 = "e0e53eb402efe4693417db8cbcc31519e74c8c74"


### PR DESCRIPTION
Now that we have some models trained, I wanted to start updating the Artifacts as well. I currently have resnets and mobilenets (I willl start ResNeXts and VGGs) and I believe @jeremiedb is also training some densenets. I wanted to open this now to clear out the which models need updating. 

We will need to make a release on Metalhead to get the weights all in one place as well, so I used a dummy repo to avoid making a release till we have the process figured out. 