### PR TITLE
Update first conv layer and default connection for ResNet

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Metalhead"
 uuid = "dbeba491-748d-5e0e-a39e-b530a07fa0cc"
-version = "0.6.1"
+version = "0.7.0-DEV"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -36,7 +36,7 @@ function bottleneck(inplanes, outplanes, downsample = false)
 end
 
 """
-    resnet(block, residuals::NTuple{2, Any}, connection = add_activate(relu);
+    resnet(block, residuals::NTuple{2, Any}, connection = addrelu;
            channel_config, block_config, nclasses = 1000)
 
 Create a ResNet model
@@ -53,7 +53,7 @@ Create a ResNet model
 - `block_config`: a list of the number of residual blocks at each stage
 - `nclasses`: the number of output classes
 """
-function resnet(block, residuals::NTuple{2, Any}, connection = add_activate(relu);
+function resnet(block, residuals::NTuple{2, Any}, connection = addrelu;
                 channel_config, block_config, nclasses = 1000)
   inplanes = 64
   baseplanes = 64
@@ -83,7 +83,7 @@ function resnet(block, residuals::NTuple{2, Any}, connection = add_activate(relu
 end
 
 """
-    resnet(block, shortcut_config::Symbol, connection = (x, y) -> @. relu(x + y);
+    resnet(block, shortcut_config::Symbol, connection = addrelu;
            channel_config, block_config, nclasses = 1000)
 
 Create a ResNet model
@@ -124,7 +124,7 @@ const resnet_config =
 
 """
     ResNet(channel_config, block_config, shortcut_config;
-           block, connection = add_activate(relu), nclasses = 1000)
+           block, connection = addrelu, nclasses = 1000)
 
 Create a `ResNet` model
 ([reference](https://arxiv.org/abs/1512.03385v1)).
@@ -144,7 +144,7 @@ struct ResNet
 end
 
 function ResNet(channel_config, block_config, shortcut_config;
-                block, connection = add_activate(relu), nclasses = 1000)
+                block, connection = addrelu, nclasses = 1000)
   layers = resnet(block,
                   shortcut_config,
                   connection;

--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -36,7 +36,7 @@ function bottleneck(inplanes, outplanes, downsample = false)
 end
 
 """
-    resnet(block, residuals::NTuple{2, Any}, connection = (x, y) -> @. relu(x + y);
+    resnet(block, residuals::NTuple{2, Any}, connection = add_activate(relu);
            channel_config, block_config, nclasses = 1000)
 
 Create a ResNet model
@@ -53,7 +53,7 @@ Create a ResNet model
 - `block_config`: a list of the number of residual blocks at each stage
 - `nclasses`: the number of output classes
 """
-function resnet(block, residuals::NTuple{2, Any}, connection = (x, y) -> @. relu(x + y);
+function resnet(block, residuals::NTuple{2, Any}, connection = add_activate(relu);
                 channel_config, block_config, nclasses = 1000)
   inplanes = 64
   baseplanes = 64
@@ -124,7 +124,7 @@ const resnet_config =
 
 """
     ResNet(channel_config, block_config, shortcut_config;
-           block, connection = (x, y) -> @. relu(x + y), nclasses = 1000)
+           block, connection = add_activate(relu), nclasses = 1000)
 
 Create a `ResNet` model
 ([reference](https://arxiv.org/abs/1512.03385v1)).
@@ -144,12 +144,12 @@ struct ResNet
 end
 
 function ResNet(channel_config, block_config, shortcut_config;
-                block, connection = (x, y) -> @. relu(x + y), nclasses = 1000)
+                block, connection = add_activate(relu), nclasses = 1000)
   layers = resnet(block,
-                  shortcut_config;
+                  shortcut_config,
+                  connection;
                   channel_config = channel_config,
                   block_config = block_config,
-                  connection = connection,
                   nclasses = nclasses)
 
   ResNet(layers)
@@ -164,7 +164,7 @@ classifier(m::ResNet) = m.layers[2]
 
 """
     ResNet(depth = 50; pretrain = false, nclasses = 1000)
-   
+
 Create a ResNet model with a specified depth
 ([reference](https://arxiv.org/abs/1512.03385v1)).
 See also [`Metalhead.resnet`](#).

--- a/src/layers.jl
+++ b/src/layers.jl
@@ -90,6 +90,28 @@ function skip_identity(inplanes, outplanes)
 end
 skip_identity(inplanes, outplanes, downsample) = skip_identity(inplanes, outplanes)
 
+"""
+    add_activate(f, x, y)
+    add_activate(f)
+
+Convenience function for `(x, y) -> @. f(x + y)`.
+Useful as the `connection` argument for [`resnet`](#).
+See also [`activate_add`](#).
+"""
+add_activate(f, x, y) = @. f(x + y)
+add_activate(f) = Base.Fix1(add_activate, f)
+
+"""
+    activate_add(f, x, y)
+    activate_add(f)
+
+Convenience function for `(x, y) -> @. f(x) + f(y)`.
+Useful as the `connection` argument for [`resnet`](#).
+See also [`add_activate`](#).
+"""
+activate_add(f, x, y) = @. f(x) + f(y)
+activate_add(f) = Base.Fix1(activate_add, f)
+
 # Patching layer used by many vision transformer-like models
 struct Patching{T <: Integer}
   patch_height::T

--- a/src/layers.jl
+++ b/src/layers.jl
@@ -91,26 +91,22 @@ end
 skip_identity(inplanes, outplanes, downsample) = skip_identity(inplanes, outplanes)
 
 """
-    add_activate(f, x, y)
-    add_activate(f)
+    addrelu(x, y)
 
-Convenience function for `(x, y) -> @. f(x + y)`.
+Convenience function for `(x, y) -> @. relu(x + y)`.
 Useful as the `connection` argument for [`resnet`](#).
-See also [`activate_add`](#).
+See also [`reluadd`](#).
 """
-add_activate(f, x, y) = @. f(x + y)
-add_activate(f) = Base.Fix1(add_activate, f)
+addrelu(x, y) = @. relu(x + y)
 
 """
-    activate_add(f, x, y)
-    activate_add(f)
+    reluadd(x, y)
 
-Convenience function for `(x, y) -> @. f(x) + f(y)`.
+Convenience function for `(x, y) -> @. relu(x) + relu(y)`.
 Useful as the `connection` argument for [`resnet`](#).
-See also [`add_activate`](#).
+See also [`addrelu`](#).
 """
-activate_add(f, x, y) = @. f(x) + f(y)
-activate_add(f) = Base.Fix1(activate_add, f)
+reluadd(x, y) = @. relu(x) + relu(y)
 
 # Patching layer used by many vision transformer-like models
 struct Patching{T <: Integer}


### PR DESCRIPTION
Fixes #110 by removing the bias from the first convolution layer and updating the default `connection` to `relu(x + y)`. Also exposes `connection` as part of the `ResNet` generic API.