### PR TITLE
ResNet: apply stride 2 to conv_bn((3,3)) as in PyTorch

### DIFF
--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -47,7 +47,7 @@ Create a ResNet model
            a new residual block (see [`Metalhead.basicblock`](#) and [`Metalhead.bottleneck`](#))
 - `residuals`: a 2-tuple of functions with input `(inplanes, outplanes, downsample=false)`,
                each of which will return a function that will be used as a new "skip" path to match a residual block.
-              [`Metalhead.skip_identity`](#) and [`Metalhead.skip_projection`](#) can be used here. 
+              [`Metalhead.skip_identity`](#) and [`Metalhead.skip_projection`](#) can be used here.
 - `connection`: the binary function applied to the output of residual and skip paths in a block
 - `channel_config`: the growth rate of the output feature maps within a residual block
 - `block_config`: a list of the number of residual blocks at each stage

--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -30,8 +30,8 @@ Create a bottleneck residual block
 """
 function bottleneck(inplanes, outplanes, downsample = false)
   stride = downsample ? 2 : 1
-  Chain(conv_bn((1, 1), inplanes, outplanes[1]; stride = stride, bias = false)...,
-        conv_bn((3, 3), outplanes[1], outplanes[2]; stride = 1, pad = 1, bias = false)...,
+  Chain(conv_bn((1, 1), inplanes, outplanes[1]; stride = 1, bias = false)...,
+        conv_bn((3, 3), outplanes[1], outplanes[2]; stride = stride, pad = 1, bias = false)...,
         conv_bn((1, 1), outplanes[2], outplanes[3], identity; stride = 1, bias = false)...)
 end
 


### PR DESCRIPTION
While comparing the PyTorch and the Metalhead.ResNet(50/101/152) model, it seems to me that the stride=2 should be applied to the convolutional layer with kernel size 3.

https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py#L133


### PyTorch:
 ```
(layer3): Sequential(
    (0): Bottleneck(
      (conv1): Conv2d(512, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)
      (bn1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
      # the following line is different
      (conv2): Conv2d(256, 256, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)  
      (bn2): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
      (conv3): Conv2d(256, 1024, kernel_size=(1, 1), stride=(1, 1), bias=False)
      (bn3): BatchNorm2d(1024, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
      (relu): ReLU(inplace=True)
      (downsample): Sequential(
        (0): Conv2d(512, 1024, kernel_size=(1, 1), stride=(2, 2), bias=False)
        (1): BatchNorm2d(1024, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
      )
    )
```

### Metalhead.ResNet(50):
```
Parallel(
        Metalhead.addrelu,
        Chain(
          Conv((1, 1), 512 => 256, stride=2, bias=false),  # 131_072 parameters
          BatchNorm(256, relu),         # 512 parameters, plus 512
          Conv((3, 3), 256 => 256, pad=1, bias=false),  # 589_824 parameters
          BatchNorm(256, relu),         # 512 parameters, plus 512
          Conv((1, 1), 256 => 1024, bias=false),  # 262_144 parameters
          BatchNorm(1024),              # 2_048 parameters, plus 2_048
        ),
        Chain(
          Conv((1, 1), 512 => 1024, stride=2, bias=false),  # 524_288 parameters
          BatchNorm(1024),              # 2_048 parameters, plus 2_048
        ),
      ),
```
With this change, I get the same results for both models (using the weights from PyTorch):

Here is for example the results of ResNet152:

```
resnet152
Flux:
acoustic guitar: 0.9387497
banjo: 0.01910968
electric guitar: 0.017470127
stage: 0.011316595
pick: 0.008845404
PyTorch:
acoustic guitar: 0.9387497
banjo: 0.019109717
electric guitar: 0.017470127
stage: 0.011316595
pick: 0.008845378
```


