### PR TITLE
VGG: use stride=2 for MaxPool like PyTorch

### DIFF
--- a/src/convnets/vgg.jl
+++ b/src/convnets/vgg.jl
@@ -42,7 +42,7 @@ function vgg_convolutional_layers(config, batchnorm, inchannels)
   ifilters = inchannels
   for c in config
     append!(layers, vgg_block(ifilters, c..., batchnorm))
-    push!(layers, MaxPool((2,2)))
+    push!(layers, MaxPool((2,2), stride=2))
     ifilters, _ = c
   end
   return layers


### PR DESCRIPTION
PyTorch uses stride=2 for the MaxPool layer:

https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py#L78

Keras uses also a stride of 2:
https://github.com/keras-team/keras-applications/blob/master/keras_applications/vgg16.py#L117

With this change I get (almost) exactly the same results with VGG11, 13, 16 and 19 for a test image and using PyTorch's weight.

```
vgg19                                                                                                                                                                 
Flux:                                                                                                                                                                 
acoustic guitar: 0.51687706                                                                                                                                           
electric guitar: 0.2988484                                                                                                                                            
stage: 0.12674169                                                                                                                                                     
pick: 0.021229278                                                                                                                                                     
banjo: 0.01773064                                                                                                                                                     
PyTorch:                                                                                                                                                              
acoustic guitar: 0.5168766                                                                                                                                            
electric guitar: 0.29884866                                                                                                                                           
stage: 0.12674181                                                                                                                                                     
pick: 0.021229278                                                                                                                                                     
banjo: 0.01773064          
```

