### PR TITLE
Update residual connection for ResNet18 and ResNet34

### DIFF
--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -212,7 +212,7 @@ resnet34 = ResNet([1, 1], [3, 4, 6, 3], :A; block = Metalhead.basicblock)
 ```
 
 The bottleneck of the orginal ResNet model has a stride of 2 on the first
-convolutional layer when downsampling (instead of the 2nd convolutional layers
+convolutional layer when downsampling (instead of the second convolutional layers
 as in ResNet v1.5). The architecture of the orignal ResNet model can be obtained
 as shown below:
 

--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -108,12 +108,17 @@ function resnet(block, shortcut_config::AbstractVector{<:Symbol}, args...; kwarg
     :B => (skip_projection, skip_identity),
     :C => (skip_projection, skip_projection))
 
-  try
-    shortcut = [shortcut_dict[sc] for sc in shortcut_config]
-  catch
+  if any(sc -> !haskey(shortcut_dict,sc),shortcut_config)
     error("Unrecognized shortcut_config ($shortcut_config) passed to `resnet` (use a vector with :A, :B, or :C).")
   end
+
+  shortcut = [shortcut_dict[sc] for sc in shortcut_config]
   resnet(block, shortcut, args...; kwargs...)
+end
+
+function resnet(block, shortcut_config::Symbol, args...; block_config, kwargs...)
+    resnet(block, fill(shortcut_config, length(block_config)), args...;
+           block_config = block_config, kwargs...)
 end
 
 const resnet_config =

--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -149,7 +149,7 @@ See also [`resnet`](#).
 - `channel_config`: the growth rate of the output feature maps within a residual block
 - `block_config`: a list of the number of residual blocks at each stage
 - `shortcut_config`: the type of shortcut style (either `:A`, `:B`, or `:C`).
-   `shortcut_config` can also be a vector or tuple of symbols if different shortcut styles are applied to
+   `shortcut_config` can also be a vector of symbols if different shortcut styles are applied to
    different residual blocks.
 - `block`: a function with input `(inplanes, outplanes, downsample=false)` that returns
            a new residual block (see [`Metalhead.basicblock`](#) and [`Metalhead.bottleneck`](#))

--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -21,11 +21,11 @@ end
 
 Create a bottleneck residual block
 ([reference](https://arxiv.org/abs/1512.03385v1)). The bottleneck is composed of
-3 convolutional layers with the given `stride`. While the original paper uses a
-stride of 2 for the first convolutional layer (if `downsample` is `true`). A
-[revised variant](https://catalog.ngc.nvidia.com/orgs/nvidia/resources/resnet_50_v1_5_for_pytorch)
-called version 1.5 uses a stride of 2 (if `downsample` is `true`) in the 2nd
-convolutional layer instead.
+3 convolutional layers each with the given `stride`.
+By default, `stride` implements ["ResNet v1.5"](https://catalog.ngc.nvidia.com/orgs/nvidia/resources/resnet_50_v1_5_for_pytorch)
+which uses `stride == [1, 2, 1]` when `downsample == true`.
+This version is standard across various ML frameworks.
+The original paper uses `stride == [2, 1, 1]` when `downsample == true` instead.
 
 # Arguments:
 - `inplanes`: the number of input feature maps

--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -208,8 +208,7 @@ using Metalhead
 
 resnet18 = ResNet([1, 1], [2, 2, 2, 2], :A; block = Metalhead.basicblock)
 
-resnet34 = ResNet([1, 1], [3, 4, 6, 3], :A;
-    block = Metalhead.basicblock)
+resnet34 = ResNet([1, 1], [3, 4, 6, 3], :A; block = Metalhead.basicblock)
 ```
 
 The bottleneck of the orginal ResNet model has a stride of 2 on the first

--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -43,6 +43,23 @@ end
 
 
 """
+    bottleneck_v1(inplanes, outplanes, downsample = false)
+
+Create a bottleneck residual block
+([reference](https://arxiv.org/abs/1512.03385v1)). The bottleneck is composed of
+3 convolutional layers with all a stride of 1 except the first convolutional
+layer which has a stride of 2.
+
+# Arguments:
+- `inplanes`: the number of input feature maps
+- `outplanes`: a list of the number of output feature maps for each convolution
+               within the residual block
+- `downsample`: set to `true` to downsample the input
+"""
+bottleneck_v1(inplanes, outplanes, downsample = false) =
+    bottleneck(inplanes, outplanes, downsample; stride = [(downsample ? 2 : 1), 1, 1])
+
+"""
     resnet(block, residuals::NTuple{2, Any}, connection = addrelu;
            channel_config, block_config, nclasses = 1000)
 
@@ -217,10 +234,7 @@ as in ResNet v1.5). The architecture of the orignal ResNet model can be obtained
 as shown below:
 
 ```julia
-bottleneck_v1(inplanes, outplanes, downsample = false) =
-    Metalhead.bottleneck(inplanes, outplanes, downsample; stride = [(downsample ? 2 : 1), 1, 1])
-
-resnet50_v1 = ResNet([1, 1, 4], [3, 4, 6, 3], :B; block = bottleneck_v1)
+resnet50_v1 = ResNet([1, 1, 4], [3, 4, 6, 3], :B; block = Metalhead.bottleneck_v1)
 ```
 """
 function ResNet(depth::Int = 50; pretrain = false, nclasses = 1000)

--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -128,9 +128,7 @@ function resnet(block, shortcut_config::Symbol, args...; block_config, kwargs...
            block_config = block_config, kwargs...)
 end
 
-function resnet(block, shortcut_config::NTuple{N,Symbol}, args...; kwargs...) where N
-    resnet(block, collect(shortcut_config), args...; kwargs...)
-end
+resnet(block, residuals::NTuple{2}, args...; kwargs...) = resnet(block, [residuals], args...; kwargs...)
 
 const resnet_config =
   Dict(18 => (([1, 1], [2, 2, 2, 2], [:A, :B, :B, :B]), basicblock),

--- a/src/convnets/resnet.jl
+++ b/src/convnets/resnet.jl
@@ -206,8 +206,7 @@ shortcuts:
 ```julia
 using Metalhead
 
-resnet18 = ResNet([1, 1], [2, 2, 2, 2], :A;
-    block = Metalhead.basicblock)
+resnet18 = ResNet([1, 1], [2, 2, 2, 2], :A; block = Metalhead.basicblock)
 
 resnet34 = ResNet([1, 1], [3, 4, 6, 3], :A;
     block = Metalhead.basicblock)


### PR DESCRIPTION
I noticed that for ResNet18 and ResNet34, PyTorch uses `skip_projection` (including a `Conv((1,))` and a `BatchNorm`) for the first parallel layer of all blocks except the first one (previously all parallel layers use `skip_identity` for these two configurations).

Note the `downsample` part is different:
```
[...]
(layer2): Sequential(
   (0): BasicBlock(
      (conv1): Conv2d(64, 128, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)
      (bn1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
      (relu): ReLU(inplace=True)
      (conv2): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
      (bn2): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
      (downsample): Sequential(
        (0): Conv2d(64, 128, kernel_size=(1, 1), stride=(2, 2), bias=False)
        (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
      )
 )
[...]
```
The current Metalhead has only a `MaxPool((1, 1), stride=2)` for downsampling.

```
 Parallel(                                                                                                                                                       
        Metalhead.addrelu,                                                                                                                                            
        Chain(                                                                                                                                                        
          Conv((3, 3), 64 => 128, pad=1, stride=2, bias=false),  # 73_728 parameters                                                                                  
          BatchNorm(128, relu),         # 256 parameters, plus 256                                                                                                    
          Conv((3, 3), 128 => 128, pad=1, bias=false),  # 147_456 parameters                                                                                          
          BatchNorm(128),               # 256 parameters, plus 256                                                                                                    
        ),                                                                                                                                                            
        Chain(MaxPool((1, 1), stride=2), #2),                                                                                                                         
      ),      
```

With this change, Metalhead.ResNet18 and Metalhead.ResNet34 are same as PyTorch.
~~If preferred, I can also change the PR to use two `residual` parameters for the `resnet` function: one `residual` parameter for the 1st layer (`firstresidual`) and one for the other layer (`residual`)~~. In the revised PR, `residual`and `shortcut_config` are vectors to allow for different type of connections for different blocks.

This should be all for the ResNet and VGG models.
 