### PR TITLE
Refactor SE layer, inverted bottleneck, and MobileNet utilities

### DIFF
--- a/src/layers.jl
+++ b/src/layers.jl
@@ -130,7 +130,7 @@ function invertedresidual(kernel_size, inplanes, hidden_planes, outplanes, activ
                           stride, reduction = nothing)
   @assert stride in [1, 2] "`stride` has to be 1 or 2"
 
-  pad = (kernel_size - 1) ÷ 2
+  pad = @. (kernel_size - 1) ÷ 2
   conv1 = (inplanes == hidden_planes) ? () : conv_bn((1, 1), inplanes, hidden_planes, activation; bias = false)
   selayer = isnothing(reduction) ? identity : squeeze_excite(hidden_planes, reduction)
 

--- a/src/layers.jl
+++ b/src/layers.jl
@@ -112,17 +112,19 @@ end
     invertedresidual(kernel_size, inplanes, hidden_planes, outplanes, activation = relu;
                      stride, reduction = nothing)
 
-Create a basic inverted residual block for MobileNetv3
+Create a basic inverted residual block for MobileNet variants
 ([reference](https://arxiv.org/abs/1905.02244)).
 
 # Arguments
+- `kernel_size`: The kernel size of the convolutional layers
 - `inplanes`: The number of input feature maps
 - `hidden_planes`: The number of feature maps in the hidden layer
 - `outplanes`: The number of output feature maps
-- `kernel_size`: The kernel size of the convolutional layers
+- `activation`: The activation function for the first two convolution layer
 - `stride`: The stride of the convolutional kernel, has to be either 1 or 2
-- `use_se`: If `true`, Squeeze and Excitation layer will be used
-- `use_hs`: If `true`, Hard-Swish activation function will be used
+- `reduction`: The reduction factor for the number of hidden feature maps
+               in a squeeze and excite layer (see [`squeeze_excite`](#)).
+               Must be >= 1 or `nothing` for no squeeze and excite layer.
 """
 function invertedresidual(kernel_size, inplanes, hidden_planes, outplanes, activation = relu;
                           stride, reduction = nothing)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -6,7 +6,7 @@ _seconddimmean(x) = dropdims(mean(x, dims = 2); dims = 2)
 function _round_channels(channels, divisor, min_value = divisor)
   new_channels = max(min_value, floor(Int, channels + divisor / 2) ÷ divisor * divisor)
   # Make sure that round down does not go down by more than 10%
-  return (new_channels < 0.9 * v) ? new_channels + divisor : new_channels
+  return (new_channels < 0.9 * channels) ? new_channels + divisor : new_channels
 end
 
 """

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,6 +1,14 @@
 # Utility function for classifier head of vision transformer-like models
 _seconddimmean(x) = dropdims(mean(x, dims = 2); dims = 2)
 
+# utility function for making sure that all layers have a channel size divisible by 8
+# used by MobileNet variants
+function _round_channels(channels, divisor, min_value = divisor)
+  new_channels = max(min_value, floor(Int, channels + divisor / 2) ÷ divisor * divisor)
+  # Make sure that round down does not go down by more than 10%
+  return (new_channels < 0.9 * v) ? new_channels + divisor : new_channels
+end
+
 """
     addrelu(x, y)
 


### PR DESCRIPTION
This refactors the squeeze and excite (SE) layer and inverted bottleneck layer to make them easier to use with other models. Previously, each MobileNet variant used its own variant of the inverted bottleneck layer. In #113, many of the functions are being reused. So, the motivation for this PR is to make the codepaths shared across these models.

There is now a single `invertedresidual` function that is used by both MobileNet v2 + v3. The activation function can be any function, and the configs/builders for each variant select the specific ones for those models. It also accepts the reduction factor for the SE layer as a keyword. One upside of this that the MobileNet v3 config can now allow a user to specify arbitrary reduction factors (previously it was 4 or no SE).

I've moved and renamed `selayer` to `squeeze_excite`. The former is fine for primarily internal use, but now this function is intended to be a reusable block. No functional changes.

I also moved and renamed `_make_divisible` to `_round_channels` just to make it more clear. Maybe there's a better name, but it is internal.