### PR TITLE
Minor fixes for ConNeXt

### DIFF
--- a/src/convnets/convnext.jl
+++ b/src/convnets/convnext.jl
@@ -58,7 +58,7 @@ function convnext(depths, planes; inchannels = 3, drop_path_rate = 0., λ = 1f-6
     cur += depths[i]
   end
 
-  backbone = collect(Iterators.flatten(Iterators.flatten((zip(downsample_layers, stages)))))
+  backbone = collect(Iterators.flatten(Iterators.flatten(zip(downsample_layers, stages))))
   head = Chain(GlobalMeanPool(),
                MLUtils.flatten,
                LayerNorm(planes[end]),

--- a/src/convnets/convnext.jl
+++ b/src/convnets/convnext.jl
@@ -58,13 +58,13 @@ function convnext(depths, planes; inchannels = 3, drop_path_rate = 0., λ = 1f-6
     cur += depths[i]
   end
 
-  layers = collect(Iterators.flatten(Iterators.flatten((zip(downsample_layers, stages)))))
-
+  backbone = collect(Iterators.flatten(Iterators.flatten((zip(downsample_layers, stages)))))
   head = Chain(GlobalMeanPool(),
                MLUtils.flatten,
                LayerNorm(planes[end]),
                Dense(planes[end], nclasses))
-  return Chain(layers..., head)
+
+  return Chain(Chain(backbone...), head)
 end
 
 # Configurations for ConvNeXt models
@@ -90,7 +90,8 @@ Creates a ConvNeXt model.
 - `λ`: Init value for [LayerScale](https://arxiv.org/abs/2103.17239)
 - `nclasses`: number of output classes
 """
-function ConvNeXt(mode::Symbol = :base; inchannels = 3, drop_path_rate = 0., λ = 1f-6, nclasses = 1000)
+function ConvNeXt(mode::Symbol = :base; inchannels = 3, drop_path_rate = 0., λ = 1f-6, 
+                  nclasses = 1000)
   depths = convnext_configs[mode][:depths]
   planes = convnext_configs[mode][:planes]
   layers = convnext(depths, planes; inchannels, drop_path_rate, λ, nclasses)

--- a/src/convnets/convnext.jl
+++ b/src/convnets/convnext.jl
@@ -16,7 +16,7 @@ function convnextblock(planes, drop_path_rate = 0., λ = 1f-6)
   layers = SkipConnection(Chain(DepthwiseConv((7, 7), planes => planes; pad = 3), 
                                 x -> permutedims(x, (3, 1, 2, 4)),
                                 LayerNorm(planes; ϵ = 1f-6),
-                                mlpblock(planes, 4 * planes),
+                                mlp_block(planes, 4 * planes),
                                 scale, # LayerScale
                                 x -> permutedims(x, (2, 3, 1, 4)),
                                 Dropout(drop_path_rate, dims = 4)), +)

--- a/src/layers/Layers.jl
+++ b/src/layers/Layers.jl
@@ -18,7 +18,7 @@ export Attention, MHAttention,
        PatchEmbedding, ViPosEmbedding, ClassTokens,
        mlpblock,
        DropPath,
-       ChannelLayerNorm,
+       ChannelLayerNorm, prenorm,
        skip_identity, skip_projection,
        conv_bn,
        invertedresidual, squeeze_excite

--- a/src/layers/Layers.jl
+++ b/src/layers/Layers.jl
@@ -16,8 +16,7 @@ include("conv.jl")
 
 export Attention, MHAttention,
        PatchEmbedding, ViPosEmbedding, ClassTokens,
-       mlpblock,
-       DropPath,
+       mlp_block,
        ChannelLayerNorm, prenorm,
        skip_identity, skip_projection,
        conv_bn,

--- a/src/layers/mlp.jl
+++ b/src/layers/mlp.jl
@@ -1,5 +1,5 @@
 """
-    mlpblock(planes, hidden_planes; dropout = 0., dense = Dense, activation = gelu)
+    mlp_block(planes, hidden_planes; dropout = 0., dense = Dense, activation = gelu)
 
 Feedforward block used in many vision transformer-like models.
 
@@ -10,7 +10,7 @@ Feedforward block used in many vision transformer-like models.
 - `dense`: Type of dense layer to use in the feedforward block.
 - `activation`: Activation function to use.
 """
-function mlpblock(planes, hidden_planes; dropout = 0., dense = Dense, activation = gelu)
+function mlp_block(planes, hidden_planes; dropout = 0., dense = Dense, activation = gelu)
   Chain(dense(planes, hidden_planes, activation), Dropout(dropout),
         dense(hidden_planes, planes), Dropout(dropout))
 end

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -1,5 +1,5 @@
 # Utility function for applying LayerNorm before a block
-prenorm(planes, fn) = Chain(fn, LayerNorm(planes))
+prenorm(planes, fn) = Chain(LayerNorm(planes), fn)
 
 """
     ChannelLayerNorm(sz::Int, λ = identity; ϵ = 1f-5)

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -1,9 +1,12 @@
+# Utility function for applying LayerNorm before a block
+prenorm(planes, fn) = Chain(fn, LayerNorm(planes))
+
 """
     ChannelLayerNorm(sz::Int, λ = identity; ϵ = 1f-5)
 
 A variant of LayerNorm where the input is normalised along the
 channel dimension. The input is expected to have channel dimension with size 
-`sz`. It also applies a learnable shift and rescaling.
+`sz`. It also applies a learnable shift and rescaling after the normalization.
 
 Note that this is specifically for inputs with 4 dimensions in the format
 (H, W, C, N) where H, W are the height and width of the input, C is the number
@@ -15,11 +18,11 @@ struct ChannelLayerNorm{F,D,T}
   ϵ::T
 end
 
+@functor ChannelLayerNorm
+
 (m::ChannelLayerNorm)(x) = m.λ.(m.diag(MLUtils.normalise(x, dims = ndims(x) - 1, ϵ = m.ϵ)))
 
 function ChannelLayerNorm(sz::Int, λ = identity; ϵ = 1f-5)
   diag = Flux.Diagonal(1, 1, sz)
   return ChannelLayerNorm(λ, diag, ϵ)
 end
-
-@functor ChannelLayerNorm

--- a/src/other/mlpmixer.jl
+++ b/src/other/mlpmixer.jl
@@ -38,10 +38,10 @@ function mlpmixer(imsize::NTuple{2} = (256, 256); inchannels = 3, patch_size = 1
   layers = []
   push!(layers, PatchEmbedding(patch_size))
   push!(layers, Dense((patch_size ^ 2) * inchannels, planes))
-  append!(layers, [Chain(_residualprenorm(planes, mlpblock(num_patches, 
+  append!(layers, [Chain(_residualprenorm(planes, mlp_block(num_patches, 
                                           expansion_factor * num_patches; 
                                           dropout, dense = token_mix)),
-                         _residualprenorm(planes, mlpblock(planes, 
+                         _residualprenorm(planes, mlp_block(planes, 
                                           expansion_factor * planes; dropout, 
                                           dense = channel_mix)),) for _ in 1:depth])
 

--- a/src/vit-based/vit.jl
+++ b/src/vit-based/vit.jl
@@ -1,6 +1,3 @@
-# Utility function for applying LayerNorm before a block
-prenorm(planes, fn) = Chain(fn, LayerNorm(planes))
-
 """
     transformer_encoder(planes, depth, heads, headplanes, mlppanes; dropout = 0.)
 

--- a/src/vit-based/vit.jl
+++ b/src/vit-based/vit.jl
@@ -14,7 +14,7 @@ Transformer as used in the base ViT architecture.
 """
 function transformer_encoder(planes, depth, heads, headplanes, mlpplanes; dropout = 0.)
   layers = [Chain(SkipConnection(prenorm(planes, MHAttention(planes, headplanes, heads; dropout)), +),
-                  SkipConnection(prenorm(planes, mlpblock(planes, mlpplanes; dropout)), +)) 
+                  SkipConnection(prenorm(planes, mlp_block(planes, mlpplanes; dropout)), +)) 
             for _ in 1:depth]
 
   Chain(layers...)


### PR DESCRIPTION
This modifies some of the ConvNeXt code  - it makes the `backbone` function work as expected (earlier it wasn't because it wasn't wrapped in a `Chain`) and more significantly, cleans up `ChannelLayerNorm` quite a bit. After a lot of poking around, I figured that it isn't really used in a lot of papers (yet, at least), which is why the original paper actually writes this function from scratch. So I figured keeping it in Metalhead would be better but I've modified the docstring and the function itself to reflect the paper's implementation a lot more closely (it's cleaner too, as a result).