### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@
 
 ## Getting Started
 
-You can find the Metalhead.jl getting started guide [here](# "Quickstart").
+You can find the Metalhead.jl getting started guide [here](https://fluxml.ai/Metalhead.jl/dev/docs/tutorials/quickstart.html).


### PR DESCRIPTION
The quickstart URL was broken. I googled and found a Metalhead.jl quickstart (which, I assume, was the intended tutorial) and added it to README.md.