### PR TITLE
Fix compile times

### DIFF
--- a/src/convnets/densenet.jl
+++ b/src/convnets/densenet.jl
@@ -28,8 +28,8 @@ Create a DenseNet transition sequence
 - `outplanes`: number of output feature maps
 """
 transition(inplanes, outplanes) =
-  [conv_bn((1, 1), inplanes, outplanes; bias = false, rev = true)...,
-   MeanPool((2, 2))]
+  Chain([conv_bn((1, 1), inplanes, outplanes; bias = false, rev = true)...,
+   MeanPool((2, 2))]...)
 
 """
     dense_block(inplanes, growth_rates)
@@ -43,8 +43,8 @@ the number of output feature maps by `growth_rates` with each block
 - `growth_rates`: the growth (additive) rates of output feature maps
                   after each block (a vector of `k`s from the ref)
 """
-dense_block(inplanes, growth_rates) = [dense_bottleneck(i, o)
-  for (i, o) in zip(inplanes .+ cumsum([0, growth_rates[1:(end - 1)]...]), growth_rates)]
+dense_block(inplanes, growth_rates) = Chain([dense_bottleneck(i, o)
+  for (i, o) in zip(inplanes .+ cumsum([0, growth_rates[1:(end - 1)]...]), growth_rates)]...)
 
 """
     densenet(inplanes, growth_rates; reduction = 0.5, nclasses = 1000)
@@ -66,9 +66,9 @@ function densenet(inplanes, growth_rates; reduction = 0.5, nclasses = 1000)
   outplanes = 0
   for (i, rates) in enumerate(growth_rates)
     outplanes = inplanes + sum(rates)
-    append!(layers, dense_block(inplanes, rates))
+    push!(layers, dense_block(inplanes, rates))
     (i != length(growth_rates)) && 
-      append!(layers, transition(outplanes, floor(Int, outplanes * reduction)))
+      push!(layers, transition(outplanes, floor(Int, outplanes * reduction)))
     inplanes = floor(Int, outplanes * reduction)
   end
   push!(layers, BatchNorm(outplanes, relu))

--- a/src/convnets/vgg.jl
+++ b/src/convnets/vgg.jl
@@ -16,13 +16,13 @@ function vgg_block(ifilters, ofilters, depth, batchnorm)
   layers = []
   for _ in 1:depth
     if batchnorm
-      append!(layers, conv_bn(k, ifilters, ofilters; pad = p, bias = false))
+      push!(layers, Chain(conv_bn(k, ifilters, ofilters; pad = p, bias = false)...))
     else
       push!(layers, Conv(k, ifilters => ofilters, relu, pad = p))
     end
     ifilters = ofilters
   end
-  return layers
+  return Chain(layers...)
 end
 
 """
@@ -41,11 +41,11 @@ function vgg_convolutional_layers(config, batchnorm, inchannels)
   layers = []
   ifilters = inchannels
   for c in config
-    append!(layers, vgg_block(ifilters, c..., batchnorm))
+    push!(layers, vgg_block(ifilters, c..., batchnorm))
     push!(layers, MaxPool((2,2), stride=2))
     ifilters, _ = c
   end
-  return layers
+  return Chain(layers...)
 end
 
 """
@@ -70,7 +70,7 @@ function vgg_classifier_layers(imsize, nclasses, fcsize, dropout)
   push!(layers, Dropout(dropout))
   push!(layers, Dense(fcsize, nclasses))
 
-  return layers
+  return Chain(layers...)
 end
 
 """


### PR DESCRIPTION
`DenseNet` had a major regression in the compile time to differentiate it over the releases.

This is often times due to very long `Chain`s. This is a small fix that makes things a lot more manageable for the moment.

```Julia
julia> den = DenseNet();

julia> ip = rand(Float32, 224,224,3,1);

julia> @time gradient((m,x) -> sum(m(x)), den, ip); #before
473.703960 seconds (114.84 M allocations: 7.870 GiB, 0.61% gc ti
me, 99.48% compilation time)

julia> @time gradient((m,x) -> sum(m(x)), den, ip); # after
209.761373 seconds (103.33 M allocations: 7.180 GiB, 1.30% gc time, 98.81% compilation time)
```

This is a pattern we have across the library, so maybe something to fix elsewhere as well.
