### PR TITLE
Expose `nclasses` option for `DenseNet`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Metalhead"
 uuid = "dbeba491-748d-5e0e-a39e-b530a07fa0cc"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/convnets/densenet.jl
+++ b/src/convnets/densenet.jl
@@ -147,9 +147,9 @@ Set `pretrain = true` to load the model with pre-trained weights for ImageNet.
 
 See also [`Metalhead.densenet`](#).
 """
-function DenseNet(config::Int = 121; pretrain = false)
+function DenseNet(config::Int = 121; pretrain = false, nclasses = 1000)
   @assert config in keys(densenet_config) "`config` must be one out of $(sort(collect(keys(densenet_config))))."
-  model = DenseNet(densenet_config[config])
+  model = DenseNet(densenet_config[config]; nclasses = nclasses)
 
   pretrain && loadpretrain!(model, string("DenseNet", config))
   return model


### PR DESCRIPTION
Previously, the `nclasses` option was not exposed for the `DenseNet` API with the `config` option. 

This PR adds that. Would be good to have a patch release too if possible (only with this commit and not the previous breaking change), since I'm trying to train some models and this will help with that 😅