### PR TITLE
Removed extra mobilenetv1 fc layer, fcsize param

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Metalhead"
 uuid = "dbeba491-748d-5e0e-a39e-b530a07fa0cc"
-version = "0.7.3"
+version = "0.8.0-DEV"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/convnets/mobilenet.jl
+++ b/src/convnets/mobilenet.jl
@@ -21,7 +21,6 @@ Create a MobileNetv1 model ([reference](https://arxiv.org/abs/1704.04861v1)).
       + `r`: The number of time this configuration block is repeated
   - `activate`: The activation function to use throughout the network
   - `inchannels`: The number of input channels. The default value is 3.
-  - `fcsize`: The intermediate fully-connected size between the convolution and final layers
   - `nclasses`: The number of output classes
 """
 function mobilenetv1(width_mult, config;

--- a/src/convnets/mobilenet.jl
+++ b/src/convnets/mobilenet.jl
@@ -4,7 +4,6 @@
     mobilenetv1(width_mult, config;
                 activation = relu,
                 inchannels = 3,
-                fcsize = 1024,
                 nclasses = 1000)
 
 Create a MobileNetv1 model ([reference](https://arxiv.org/abs/1704.04861v1)).
@@ -28,7 +27,6 @@ Create a MobileNetv1 model ([reference](https://arxiv.org/abs/1704.04861v1)).
 function mobilenetv1(width_mult, config;
                      activation = relu,
                      inchannels = 3,
-					     fcsize = 1024,
                      nclasses = 1000)
     layers = []
     for (dw, outch, stride, nrepeats) in config
@@ -47,8 +45,7 @@ function mobilenetv1(width_mult, config;
     return Chain(Chain(layers),
                  Chain(GlobalMeanPool(),
                        MLUtils.flatten,
-                       Dense(inchannels, fcsize, activation),
-                       Dense(fcsize, nclasses)))
+                       Dense(inchannels, nclasses)))
 end
 
 const mobilenetv1_configs = [


### PR DESCRIPTION
#186  
My first PR! Thanks @theabhirath for a good first issue. I found that the best way to fix was to also remove the `fcsize` parameter. It's not used by the non-configurable function, so I'm assuming it's not used much.  

It's also an option to set `fcsize = nothing` and add extra layer if `fcsize !== nothing`.