### PR TITLE
Do not catch orthogonal errors when loading

### DIFF
--- a/src/pretrain.jl
+++ b/src/pretrain.jl
@@ -4,16 +4,17 @@
 Load the pre-trained weights for `model` using the stored artifacts.
 """
 function weights(model)
-    try
-        path = joinpath(@artifact_str(model), "$model.bson")
-        artifact = BSON.load(path, @__MODULE__)
-        if haskey(artifact, :model)
-            return artifact[:model]
-        else
-            throw(ArgumentError("No pre-trained weights available for $model."))
-        end
+    path = try
+        joinpath(@artifact_str(model), "$model.bson")
     catch e
         throw(ArgumentError("No pre-trained weights available for $model."))
+    end
+
+    artifact = BSON.load(path, @__MODULE__)
+    if haskey(artifact, :model)
+        return artifact[:model]
+    else
+        throw(ErrorException("Found weight artifact for $model but the weights are not saved under the key :model."))
     end
 end
 


### PR DESCRIPTION
This just limits the `try`/`catch` to finding the artifact instead of any error.