### PR TITLE
Tweak GoogLeNet to match the torchvision implementations

### DIFF
--- a/src/convnets/inceptions/googlenet.jl
+++ b/src/convnets/inceptions/googlenet.jl
@@ -16,14 +16,21 @@ Create an inception module for use in GoogLeNet
   - `batchnorm`: set to `true` to include batch normalization after each convolution
   - `bias`: set to `true` to use bias in the convolution layers.
 """
-function inceptionblock(inplanes, out_1x1, red_3x3, out_3x3, red_5x5, out_5x5, pool_proj, batchnorm, bias)
-    branch1 = Chain(basic_conv_bn((1, 1), inplanes, out_1x1; batchnorm = batchnorm, bias = bias)...)
-    branch2 = Chain(basic_conv_bn((1, 1), inplanes, red_3x3; batchnorm = batchnorm, bias = bias)...,
-                    basic_conv_bn((3, 3), red_3x3, out_3x3; batchnorm = batchnorm, bias = bias, pad = 1)...)
-    branch3 = Chain(basic_conv_bn((1, 1), inplanes, red_5x5; batchnorm = batchnorm, bias = bias)...,
-                    basic_conv_bn((5, 5), red_5x5, out_5x5; batchnorm = batchnorm, bias = bias, pad = 2)...)
+function inceptionblock(inplanes, out_1x1, red_3x3, out_3x3, red_5x5, out_5x5, pool_proj,
+                        batchnorm, bias)
+    branch1 = Chain(basic_conv_bn((1, 1), inplanes, out_1x1; batchnorm = batchnorm,
+                                  bias = bias)...)
+    branch2 = Chain(basic_conv_bn((1, 1), inplanes, red_3x3; batchnorm = batchnorm,
+                                  bias = bias)...,
+                    basic_conv_bn((3, 3), red_3x3, out_3x3; batchnorm = batchnorm,
+                                  bias = bias, pad = 1)...)
+    branch3 = Chain(basic_conv_bn((1, 1), inplanes, red_5x5; batchnorm = batchnorm,
+                                  bias = bias)...,
+                    basic_conv_bn((5, 5), red_5x5, out_5x5; batchnorm = batchnorm,
+                                  bias = bias, pad = 2)...)
     branch4 = Chain(MaxPool((3, 3); stride = 1, pad = 1),
-                    basic_conv_bn((1, 1), inplanes, pool_proj; batchnorm = batchnorm, bias = bias)...)
+                    basic_conv_bn((1, 1), inplanes, pool_proj; batchnorm = batchnorm,
+                                  bias = bias)...)
     return Parallel(cat_channels,
                     branch1, branch2, branch3, branch4)
 end
@@ -42,11 +49,14 @@ Create an Inception-v1 model (commonly referred to as GoogLeNet)
   - `batchnorm`: set to `true` to include batch normalization after each convolution
   - `bias`: set to `true` to use bias in the convolution layers
 """
-function googlenet(; dropout_prob = 0.4, inchannels::Integer = 3, nclasses::Integer = 1000, batchnorm::Bool=false, bias::Bool=true)
-    backbone = Chain(basic_conv_bn((7, 7), inchannels, 64; batchnorm = batchnorm, stride = 2, pad = 3, bias = bias)...,
+function googlenet(; dropout_prob = 0.4, inchannels::Integer = 3, nclasses::Integer = 1000,
+                   batchnorm::Bool = false, bias::Bool = true)
+    backbone = Chain(basic_conv_bn((7, 7), inchannels, 64; batchnorm = batchnorm,
+                                   stride = 2, pad = 3, bias = bias)...,
                      MaxPool((3, 3); stride = 2, pad = 1),
                      basic_conv_bn((1, 1), 64, 64; batchnorm = batchnorm, bias = bias)...,
-                     basic_conv_bn((3, 3), 64, 192; batchnorm = batchnorm, pad = 1, bias = bias)...,
+                     basic_conv_bn((3, 3), 64, 192; batchnorm = batchnorm, pad = 1,
+                                   bias = bias)...,
                      MaxPool((3, 3); stride = 2, pad = 1),
                      inceptionblock(192, 64, 96, 128, 16, 32, 32, batchnorm, bias),
                      inceptionblock(256, 128, 128, 192, 32, 96, 64, batchnorm, bias),
@@ -87,7 +97,7 @@ end
 @functor GoogLeNet
 
 function GoogLeNet(; pretrain::Bool = false, inchannels::Integer = 3,
-                   nclasses::Integer = 1000, batchnorm::Bool = false, bias::Bool=true)
+                   nclasses::Integer = 1000, batchnorm::Bool = false, bias::Bool = true)
     layers = googlenet(; inchannels, nclasses, batchnorm, bias)
     if pretrain
         loadpretrain!(layers, "GoogLeNet")

--- a/src/convnets/inceptions/googlenet.jl
+++ b/src/convnets/inceptions/googlenet.jl
@@ -44,8 +44,8 @@ Create an Inception-v1 model (commonly referred to as GoogLeNet)
   - `bias`: set to `true` to use bias in the convolution layers
 """
 function googlenet(; dropout_prob = 0.4, inchannels::Integer = 3, nclasses::Integer = 1000, batchnorm::Bool=false, bias::Bool=true)
-    norm_layer = batchnorm ? BatchNorm : identity
-    backbone = Chain(conv_norm((7, 7), inchannels, 64, identity; norm_layer = norm_layer, stride = 2, pad = 3, bias = bias)...,
+    norm_layer = batchnorm ? (args...; kwargs...) -> BatchNorm(args...; ϵ = 1.0f-3) : identity
+    backbone = Chain(conv_norm((7, 7), inchannels, 64; norm_layer = norm_layer, stride = 2, pad = 3, bias = bias)...,
                      MaxPool((3, 3); stride = 2, pad = 1),
                      conv_norm((1, 1), 64, 64, identity; norm_layer = norm_layer, bias = bias)...,
                      conv_norm((3, 3), 64, 192, identity; norm_layer = norm_layer, pad = 1, bias = bias)...,
@@ -90,7 +90,7 @@ end
 
 function GoogLeNet(; pretrain::Bool = false, inchannels::Integer = 3,
                    nclasses::Integer = 1000, batchnorm::Bool = false, bias::Bool=true)
-    layers = googlenet(; inchannels, nclasses)
+    layers = googlenet(; inchannels, nclasses, batchnorm, bias)
     if pretrain
         loadpretrain!(layers, "GoogLeNet")
     end

--- a/src/convnets/inceptions/googlenet.jl
+++ b/src/convnets/inceptions/googlenet.jl
@@ -13,6 +13,9 @@ Create an inception module for use in GoogLeNet
   - `red_5x5`: the number of output feature maps for the 5x5 reduction convolution (branch 3)
   - `out_5x5`: the number of output feature maps for the 5x5 convolution (branch 3)
   - `pool_proj`: the number of output feature maps for the pooling projection (branch 4)
+  - `norm_layer`: the normalisation layer used. Note that using `identity` as the normalisation
+  layer will result in no normalisation being applied.
+  - `bias`: set to `true` to use bias in the convolution layers.
 """
 function inceptionblock(inplanes, out_1x1, red_3x3, out_3x3, red_5x5, out_5x5, pool_proj, norm_layer, bias)
     branch1 = Chain(conv_norm((1, 1), inplanes, out_1x1, identity; norm_layer = norm_layer, bias = bias)...)
@@ -37,6 +40,8 @@ Create an Inception-v1 model (commonly referred to as GoogLeNet)
   - `dropout_prob`: the dropout probability in the classifier head. Set to `nothing` to disable dropout.
   - `inchannels`: the number of input channels
   - `nclasses`: the number of output classes
+  - `batchnorm`: set to `true` to include batch normalization after each convolution
+  - `bias`: set to `true` to use bias in the convolution layers
 """
 function googlenet(; dropout_prob = 0.4, inchannels::Integer = 3, nclasses::Integer = 1000, batchnorm::Bool=false, bias::Bool=true)
     norm_layer = batchnorm ? BatchNorm : identity
@@ -69,6 +74,8 @@ Create an Inception-v1 model (commonly referred to as `GoogLeNet`)
 
   - `pretrain`: set to `true` to load the model with pre-trained weights for ImageNet
   - `nclasses`: the number of output classes
+  - `batchnorm`: set to `true` to use batch normalization after each convolution
+  - `bias`: set to `true` to use bias in the convolution layers
 
 !!! warning
     

--- a/src/convnets/inceptions/googlenet.jl
+++ b/src/convnets/inceptions/googlenet.jl
@@ -45,7 +45,7 @@ Create an Inception-v1 model (commonly referred to as GoogLeNet)
 """
 function googlenet(; dropout_prob = 0.4, inchannels::Integer = 3, nclasses::Integer = 1000, batchnorm::Bool=false, bias::Bool=true)
     norm_layer = batchnorm ? (args...; kwargs...) -> BatchNorm(args...; ϵ = 1.0f-3) : identity
-    backbone = Chain(conv_norm((7, 7), inchannels, 64; norm_layer = norm_layer, stride = 2, pad = 3, bias = bias)...,
+    backbone = Chain(conv_norm((7, 7), inchannels, 64, identity; norm_layer = norm_layer, stride = 2, pad = 3, bias = bias)...,
                      MaxPool((3, 3); stride = 2, pad = 1),
                      conv_norm((1, 1), 64, 64, identity; norm_layer = norm_layer, bias = bias)...,
                      conv_norm((3, 3), 64, 192, identity; norm_layer = norm_layer, pad = 1, bias = bias)...,

--- a/src/convnets/inceptions/googlenet.jl
+++ b/src/convnets/inceptions/googlenet.jl
@@ -38,7 +38,7 @@ Create an Inception-v1 model (commonly referred to as GoogLeNet)
   - `inchannels`: the number of input channels
   - `nclasses`: the number of output classes
 """
-function googlenet(; dropout_prob = 0.4, inchannels::Integer = 3, nclasses::Integer = 1000, batchnorm::Bool=false, bias::Bool=false)
+function googlenet(; dropout_prob = 0.4, inchannels::Integer = 3, nclasses::Integer = 1000, batchnorm::Bool=false, bias::Bool=true)
     norm_layer = batchnorm ? BatchNorm : identity
     backbone = Chain(conv_norm((7, 7), inchannels, 64, identity; norm_layer = norm_layer, stride = 2, pad = 3, bias = bias)...,
                      MaxPool((3, 3); stride = 2, pad = 1),
@@ -82,7 +82,7 @@ end
 @functor GoogLeNet
 
 function GoogLeNet(; pretrain::Bool = false, inchannels::Integer = 3,
-                   nclasses::Integer = 1000, batchnorm::Bool = false)
+                   nclasses::Integer = 1000, batchnorm::Bool = false, bias::Bool=true)
     layers = googlenet(; inchannels, nclasses)
     if pretrain
         loadpretrain!(layers, "GoogLeNet")

--- a/src/convnets/inceptions/googlenet.jl
+++ b/src/convnets/inceptions/googlenet.jl
@@ -14,14 +14,14 @@ Create an inception module for use in GoogLeNet
   - `out_5x5`: the number of output feature maps for the 5x5 convolution (branch 3)
   - `pool_proj`: the number of output feature maps for the pooling projection (branch 4)
 """
-function inceptionblock(inplanes, out_1x1, red_3x3, out_3x3, red_5x5, out_5x5, pool_proj)
-    branch1 = Chain(Conv((1, 1), inplanes => out_1x1))
-    branch2 = Chain(Conv((1, 1), inplanes => red_3x3),
-                    Conv((3, 3), red_3x3 => out_3x3; pad = 1))
-    branch3 = Chain(Conv((1, 1), inplanes => red_5x5),
-                    Conv((5, 5), red_5x5 => out_5x5; pad = 2))
+function inceptionblock(inplanes, out_1x1, red_3x3, out_3x3, red_5x5, out_5x5, pool_proj, norm_layer, bias)
+    branch1 = Chain(conv_norm((1, 1), inplanes, out_1x1, identity; norm_layer = norm_layer, bias = bias)...)
+    branch2 = Chain(conv_norm((1, 1), inplanes, red_3x3, identity; norm_layer = norm_layer, bias = bias)...,
+                    conv_norm((3, 3), red_3x3, out_3x3, identity; norm_layer = norm_layer, bias = bias, pad = 1)...)
+    branch3 = Chain(conv_norm((1, 1), inplanes, red_5x5, identity; norm_layer = norm_layer, bias = bias)...,
+                    conv_norm((5, 5), red_5x5, out_5x5, identity; norm_layer = norm_layer, bias = bias, pad = 2)...)
     branch4 = Chain(MaxPool((3, 3); stride = 1, pad = 1),
-                    Conv((1, 1), inplanes => pool_proj))
+                    conv_norm((1, 1), inplanes, pool_proj, identity; norm_layer = norm_layer, bias = bias)...)
     return Parallel(cat_channels,
                     branch1, branch2, branch3, branch4)
 end
@@ -38,23 +38,24 @@ Create an Inception-v1 model (commonly referred to as GoogLeNet)
   - `inchannels`: the number of input channels
   - `nclasses`: the number of output classes
 """
-function googlenet(; dropout_prob = 0.4, inchannels::Integer = 3, nclasses::Integer = 1000)
-    backbone = Chain(Conv((7, 7), inchannels => 64; stride = 2, pad = 3),
+function googlenet(; dropout_prob = 0.4, inchannels::Integer = 3, nclasses::Integer = 1000, batchnorm::Bool=false, bias::Bool=false)
+    norm_layer = batchnorm ? BatchNorm : identity
+    backbone = Chain(conv_norm((7, 7), inchannels, 64, identity; norm_layer = norm_layer, stride = 2, pad = 3, bias = bias)...,
                      MaxPool((3, 3); stride = 2, pad = 1),
-                     Conv((1, 1), 64 => 64),
-                     Conv((3, 3), 64 => 192; pad = 1),
+                     conv_norm((1, 1), 64, 64, identity; norm_layer = norm_layer, bias = bias)...,
+                     conv_norm((3, 3), 64, 192, identity; norm_layer = norm_layer, pad = 1, bias = bias)...,
                      MaxPool((3, 3); stride = 2, pad = 1),
-                     inceptionblock(192, 64, 96, 128, 16, 32, 32),
-                     inceptionblock(256, 128, 128, 192, 32, 96, 64),
+                     inceptionblock(192, 64, 96, 128, 16, 32, 32, norm_layer, bias),
+                     inceptionblock(256, 128, 128, 192, 32, 96, 64, norm_layer, bias),
                      MaxPool((3, 3); stride = 2, pad = 1),
-                     inceptionblock(480, 192, 96, 208, 16, 48, 64),
-                     inceptionblock(512, 160, 112, 224, 24, 64, 64),
-                     inceptionblock(512, 128, 128, 256, 24, 64, 64),
-                     inceptionblock(512, 112, 144, 288, 32, 64, 64),
-                     inceptionblock(528, 256, 160, 320, 32, 128, 128),
+                     inceptionblock(480, 192, 96, 208, 16, 48, 64, norm_layer, bias),
+                     inceptionblock(512, 160, 112, 224, 24, 64, 64, norm_layer, bias),
+                     inceptionblock(512, 128, 128, 256, 24, 64, 64, norm_layer, bias),
+                     inceptionblock(512, 112, 144, 288, 32, 64, 64, norm_layer, bias),
+                     inceptionblock(528, 256, 160, 320, 32, 128, 128, norm_layer, bias),
                      MaxPool((3, 3); stride = 2, pad = 1),
-                     inceptionblock(832, 256, 160, 320, 32, 128, 128),
-                     inceptionblock(832, 384, 192, 384, 48, 128, 128))
+                     inceptionblock(832, 256, 160, 320, 32, 128, 128, norm_layer, bias),
+                     inceptionblock(832, 384, 192, 384, 48, 128, 128, norm_layer, bias))
     return Chain(backbone, create_classifier(1024, nclasses; dropout_prob))
 end
 
@@ -81,7 +82,7 @@ end
 @functor GoogLeNet
 
 function GoogLeNet(; pretrain::Bool = false, inchannels::Integer = 3,
-                   nclasses::Integer = 1000)
+                   nclasses::Integer = 1000, batchnorm::Bool = false)
     layers = googlenet(; inchannels, nclasses)
     if pretrain
         loadpretrain!(layers, "GoogLeNet")

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -81,6 +81,8 @@ TensorFlow implementation.
 function basic_conv_bn(kernel_size::Dims{2}, inplanes, outplanes, activation = relu;
                        batchnorm::Bool = true, kwargs...)
     # TensorFlow uses a default epsilon of 1e-3 for BatchNorm
-    norm_layer = batchnorm ? (args...; kwargs...) -> BatchNorm(args...; ϵ = 1.0f-3, kwargs...) : identity
+    norm_layer = batchnorm ?
+                 (args...; kwargs...) -> BatchNorm(args...; ϵ = 1.0f-3, kwargs...) :
+                 identity
     return conv_norm(kernel_size, inplanes, outplanes, activation; norm_layer, kwargs...)
 end

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -75,11 +75,12 @@ TensorFlow implementation.
   - `inplanes`: number of input feature maps
   - `outplanes`: number of output feature maps
   - `activation`: the activation function for the final layer
+  - `batchnorm`: set to `true` to include batch normalization after each convolution
   - `kwargs`: keyword arguments passed to [`conv_norm`](@ref)
 """
 function basic_conv_bn(kernel_size::Dims{2}, inplanes, outplanes, activation = relu;
-                       kwargs...)
+                       batchnorm::Bool = true, kwargs...)
     # TensorFlow uses a default epsilon of 1e-3 for BatchNorm
-    norm_layer = (args...; kwargs...) -> BatchNorm(args...; ϵ = 1.0f-3, kwargs...)
+    norm_layer = batchnorm ? (args...; kwargs...) -> BatchNorm(args...; ϵ = 1.0f-3, kwargs...) : identity
     return conv_norm(kernel_size, inplanes, outplanes, activation; norm_layer, kwargs...)
 end

--- a/test/convnets.jl
+++ b/test/convnets.jl
@@ -195,10 +195,10 @@ end
     @testset for bn in [true, false]
         m = GoogLeNet(batchnorm = bn)
         @test size(m(x_224)) == (1000, 1)
-        if GoogLeNet in PRETRAINED_MODELS
-            @test acctest(GoogLeNet(pretrain = true))
+        if (GoogLeNet, bn) in PRETRAINED_MODELS
+            @test acctest(GoogLeNet(batchnorm = bn, pretrain = true))
         else
-            @test_throws ArgumentError GoogLeNet(pretrain = true)
+            @test_throws ArgumentError GoogLeNet(batchnorm = bn, pretrain = true)
         end
         @test gradtest(m, x_224)
         _gc()

--- a/test/convnets.jl
+++ b/test/convnets.jl
@@ -192,15 +192,17 @@ end
 end
 
 @testset "GoogLeNet" begin
-    m = GoogLeNet()
-    @test size(m(x_224)) == (1000, 1)
-    if GoogLeNet in PRETRAINED_MODELS
-        @test acctest(GoogLeNet(pretrain = true))
-    else
-        @test_throws ArgumentError GoogLeNet(pretrain = true)
+    @testset bn in [true, false]
+        m = GoogLeNet(batchnorm = bn)
+        @test size(m(x_224)) == (1000, 1)
+        if GoogLeNet in PRETRAINED_MODELS
+            @test acctest(GoogLeNet(pretrain = true))
+        else
+            @test_throws ArgumentError GoogLeNet(pretrain = true)
+        end
+        @test gradtest(m, x_224)
+        _gc()
     end
-    @test gradtest(m, x_224)
-    _gc()
 end
 
 @testset "Inception" begin

--- a/test/convnets.jl
+++ b/test/convnets.jl
@@ -192,7 +192,7 @@ end
 end
 
 @testset "GoogLeNet" begin
-    @testset bn in [true, false]
+    @testset for bn in [true, false]
         m = GoogLeNet(batchnorm = bn)
         @test size(m(x_224)) == (1000, 1)
         if GoogLeNet in PRETRAINED_MODELS


### PR DESCRIPTION
Changed the `Conv` layers to `conv_norm` layers. 

However, I couldn't find a way to specify eps for `BatchNorm`. The default value that flux uses is 1f-5, and torchvision version of GoogleNet has eps set to 0.001.

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable


Also ps: Unrelated, but the link to 'contributing docs' in the readme seems to be broken.