### PR TITLE
Mark resnet acctests broken

### DIFF
--- a/src/convnets/resnets/resnet.jl
+++ b/src/convnets/resnets/resnet.jl
@@ -60,7 +60,7 @@ function WideResNet(depth::Integer; pretrain::Bool = false, inchannels::Integer 
     _checkconfig(depth, keys(LRESNET_CONFIGS))
     layers = resnet(LRESNET_CONFIGS[depth]...; base_width = 128, inchannels, nclasses)
     if pretrain
-        loadpretrain!(layers, string("WideResNet", depth))
+        loadpretrain!(layers, string("wideresnet", depth))
     end
     return WideResNet(layers)
 end

--- a/test/convnets.jl
+++ b/test/convnets.jl
@@ -78,7 +78,7 @@ end
                 m = ResNeXt(depth; cardinality, base_width)
                 @test size(m(x_224)) == (1000, 1)
                 if (ResNeXt, depth, cardinality, base_width) in PRETRAINED_MODELS
-                    @test acctest(ResNeXt(depth; cardinality, base_width, pretrain = true))
+                    @test_broken acctest(ResNeXt(depth; cardinality, base_width, pretrain = true))
                 else
                     @test_throws ArgumentError ResNeXt(depth; cardinality, base_width, pretrain = true)
                 end

--- a/test/convnets.jl
+++ b/test/convnets.jl
@@ -125,7 +125,7 @@ end
     @testset for (base_width, scale) in [(26, 4), (48, 2), (14, 8), (26, 6), (26, 8)]
         m = Res2Net(50; base_width, scale)
         @test size(m(x_224)) == (1000, 1)
-        if (Res2Net, depth, base_width, scale) in PRETRAINED_MODELS
+        if (Res2Net, 50, base_width, scale) in PRETRAINED_MODELS
             @test acctest(Res2Net(50; base_width, scale, pretrain = true))
         else
             @test_throws ArgumentError Res2Net(50; base_width, scale, pretrain = true)
@@ -136,7 +136,7 @@ end
     @testset for (base_width, scale) in [(26, 4)]
         m = Res2Net(101; base_width, scale)
         @test size(m(x_224)) == (1000, 1)
-        if (Res2Net, depth, base_width, scale) in PRETRAINED_MODELS
+        if (Res2Net, 101, base_width, scale) in PRETRAINED_MODELS
             @test acctest(Res2Net(101; base_width, scale, pretrain = true))
         else
             @test_throws ArgumentError Res2Net(101; base_width, scale, pretrain = true)

--- a/test/convnets.jl
+++ b/test/convnets.jl
@@ -63,7 +63,7 @@ end
             @test gradtest(m, x_224)
             _gc()
             if (WideResNet, sz) in PRETRAINED_MODELS
-                @test acctest(ResNet(sz, pretrain = true))
+                @test acctest(WideResNet(sz, pretrain = true))
             else
                 @test_throws ArgumentError WideResNet(sz, pretrain = true)
             end

--- a/test/convnets.jl
+++ b/test/convnets.jl
@@ -26,7 +26,7 @@ end
         m = ResNet(sz)
         @test size(m(x_224)) == (1000, 1)
         if (ResNet, sz) in PRETRAINED_MODELS
-            @test acctest(ResNet(sz, pretrain = true))
+            @test_broken acctest(ResNet(sz, pretrain = true))
         else
             @test_throws ArgumentError ResNet(sz, pretrain = true)
         end

--- a/test/convnets.jl
+++ b/test/convnets.jl
@@ -63,7 +63,7 @@ end
             @test gradtest(m, x_224)
             _gc()
             if (WideResNet, sz) in PRETRAINED_MODELS
-                @test acctest(WideResNet(sz, pretrain = true))
+                @test_broken acctest(WideResNet(sz, pretrain = true))
             else
                 @test_throws ArgumentError WideResNet(sz, pretrain = true)
             end


### PR DESCRIPTION
These failing CI makes it harder to spot other failures, especially in downstream CI. Just a band-aid fix until we can get new weights generated.
