### PR TITLE
Update use of `Flux._isactive` in DropBlock to prevent deprecation warning

### DIFF
--- a/src/layers/drop.jl
+++ b/src/layers/drop.jl
@@ -90,12 +90,11 @@ ChainRulesCore.@non_differentiable _dropblock_checks(x, drop_block_prob, gamma_s
 
 function (m::DropBlock)(x)
     _dropblock_checks(x, m.drop_block_prob, m.gamma_scale)
-    return Flux._isactive(m) ?
-           dropblock(m.rng, x, m.drop_block_prob, m.block_size, m.gamma_scale) : x
+    return dropblock(m.rng, x, m.drop_block_prob * Flux._isactive(m, x), m.block_size, m.gamma_scale)
 end
 
 function Flux.testmode!(m::DropBlock, mode = true)
-    return (m.active = (isnothing(mode) || mode === :auto) ? nothing : !mode; m)
+    return (m.active = isnothing(Flux._tidy_active(mode)) ? nothing : !mode; m)
 end
 
 function DropBlock(drop_block_prob = 0.1, block_size::Integer = 7, gamma_scale = 1.0,


### PR DESCRIPTION
In the process of moving Dropout to NNlib, some of these functions were changed upstream. While this is obviously not ideal for Metalhead to use internal Flux functions, this is a temporary fix to prevent a deprecation warning from being printed every time the layer is used. Maybe later Flux can find a way to do this upstream that allows other libraries to extend.

cc @ToucheSir @darsnack to check if this is the way to go for now.