### PR TITLE
Fix bug where MobileNetv2/3 return a MobileNetv1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Metalhead"
 uuid = "dbeba491-748d-5e0e-a39e-b530a07fa0cc"
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/convnets/mobilenets/mobilenetv2.jl
+++ b/src/convnets/mobilenets/mobilenetv2.jl
@@ -71,7 +71,7 @@ end
 function MobileNetv2(width_mult::Real = 1; pretrain::Bool = false,
                      inchannels::Integer = 3, nclasses::Integer = 1000)
     layers = mobilenetv2(width_mult; inchannels, nclasses)
-    model = MobileNetv1(layers)
+    model = MobileNetv2(layers)
     if pretrain
         loadpretrain!(model, "mobilenet_v2")
     end

--- a/src/convnets/mobilenets/mobilenetv3.jl
+++ b/src/convnets/mobilenets/mobilenetv3.jl
@@ -91,7 +91,7 @@ end
 function MobileNetv3(config::Symbol; width_mult::Real = 1, pretrain::Bool = false,
                      inchannels::Integer = 3, nclasses::Integer = 1000)
     layers = mobilenetv3(config; width_mult, inchannels, nclasses)
-    model = MobileNetv1(layers)
+    model = MobileNetv3(layers)
     if pretrain
         loadpretrain!(model, "mobilenet_v3")
     end


### PR DESCRIPTION
The `MobileNetv2` and `MobileNetv3` constructors returned a layer of type `MobileNetv1`. The actual model itself was correct. Just the wrapper type was wrong.

### PR Checklist

- [x] ~~Tests are added~~
- [x] ~~Documentation, if applicable~~
