### PR TITLE
Fix VGG dropout probability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Metalhead"
 uuid = "dbeba491-748d-5e0e-a39e-b530a07fa0cc"
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/convnets/vgg.jl
+++ b/src/convnets/vgg.jl
@@ -103,7 +103,7 @@ const VGG_CONFIGS = Dict(11 => [(64, 1), (128, 1), (256, 2), (512, 2), (512, 2)]
 
 """
     VGG(depth::Integer; pretrain::Bool = false, batchnorm::Bool = false,
-        inchannels::Integer = 3, nclasses::Integer = 1000, dropout_prob = 0.5)
+        inchannels::Integer = 3, nclasses::Integer = 1000)
 
 Create a VGG style model with specified `depth`.
 ([reference](https://arxiv.org/abs/1409.1556v6)).

--- a/src/convnets/vgg.jl
+++ b/src/convnets/vgg.jl
@@ -103,13 +103,13 @@ const VGG_CONFIGS = Dict(11 => [(64, 1), (128, 1), (256, 2), (512, 2), (512, 2)]
 
 """
     VGG(depth::Integer; pretrain::Bool = false, batchnorm::Bool = false,
-        inchannels::Integer = 3, nclasses::Integer = 1000)
+        inchannels::Integer = 3, nclasses::Integer = 1000, dropout_prob = 0.5)
 
 Create a VGG style model with specified `depth`.
 ([reference](https://arxiv.org/abs/1409.1556v6)).
 
 !!! warning
-    
+
     `VGG` does not currently support pretrained weights for the `batchnorm = true` option.
 
 # Arguments
@@ -119,6 +119,7 @@ Create a VGG style model with specified `depth`.
 - `batchnorm`: set to `true` to use batch normalization after each convolution
 - `inchannels`: number of input channels
 - `nclasses`: number of output classes
+- `dropout_prob`: probability of `Dropout` layers setting inputs to zero
 
 See also [`vgg`](@ref).
 """
@@ -128,9 +129,9 @@ end
 @functor VGG
 
 function VGG(depth::Integer; pretrain::Bool = false, batchnorm::Bool = false,
-             inchannels::Integer = 3, nclasses::Integer = 1000)
+             inchannels::Integer = 3, nclasses::Integer = 1000, dropout_prob = 0.5)
     _checkconfig(depth, keys(VGG_CONFIGS))
-    layers = vgg((224, 224); config = VGG_CONFIGS[depth], batchnorm, inchannels, nclasses)
+    layers = vgg((224, 224); config = VGG_CONFIGS[depth], batchnorm, inchannels, nclasses, dropout_prob)
     model = VGG(layers)
     if pretrain
         artifact_name = string("vgg", depth)

--- a/src/convnets/vgg.jl
+++ b/src/convnets/vgg.jl
@@ -119,7 +119,6 @@ Create a VGG style model with specified `depth`.
 - `batchnorm`: set to `true` to use batch normalization after each convolution
 - `inchannels`: number of input channels
 - `nclasses`: number of output classes
-- `dropout_prob`: probability of `Dropout` layers setting inputs to zero
 
 See also [`vgg`](@ref).
 """
@@ -129,9 +128,10 @@ end
 @functor VGG
 
 function VGG(depth::Integer; pretrain::Bool = false, batchnorm::Bool = false,
-             inchannels::Integer = 3, nclasses::Integer = 1000, dropout_prob = 0.5)
+             inchannels::Integer = 3, nclasses::Integer = 1000)
     _checkconfig(depth, keys(VGG_CONFIGS))
-    layers = vgg((224, 224); config = VGG_CONFIGS[depth], batchnorm, inchannels, nclasses, dropout_prob)
+    layers = vgg((224, 224); config = VGG_CONFIGS[depth], batchnorm, inchannels, nclasses,
+                 dropout_prob = 0.5)
     model = VGG(layers)
     if pretrain
         artifact_name = string("vgg", depth)


### PR DESCRIPTION
Closes #271 by setting default dropout probability to 0.5 and making keyword argument `dropout_prob` accessible.